### PR TITLE
add github short sha to docker tag

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,10 +22,12 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-
+    - name: Set outputs
+      id: vars
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
     - name: Build and push Docker image
       uses: docker/build-push-action@v2
       with:
         context: .
         push: true
-        tags: grantchiu/fein-base:${{ github.sha }}
+        tags: grantchiu/fein-base:${{ steps.vars.outputs.sha_short }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved Docker image tagging by using the commit's short SHA for better traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->